### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
       - home
       - opengl
       - raw-usb
+      - removable-media
       - screen-inhibit-control
       - network
       - network-bind


### PR DESCRIPTION
Add removable-media plug so we can put VMs on a USB drive (which wimpy is doing a lot)